### PR TITLE
fix #56

### DIFF
--- a/src/br/com/dio/desafio/dominio/Conteudo.java
+++ b/src/br/com/dio/desafio/dominio/Conteudo.java
@@ -1,5 +1,7 @@
 package br.com.dio.desafio.dominio;
 
+import java.util.Objects;
+
 public abstract class Conteudo {
 
     protected static final double XP_PADRAO = 10d;
@@ -23,5 +25,19 @@ public abstract class Conteudo {
 
     public void setDescricao(String descricao) {
         this.descricao = descricao;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Conteudo)) return false;
+        Conteudo conteudo = (Conteudo) o;
+        return Objects.equals(getTitulo(), conteudo.getTitulo());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getTitulo());
     }
 }


### PR DESCRIPTION
Conteúdos agora são diferenciados por título; utilizando `equals` e `hashCode`

fix #56